### PR TITLE
Aggregate multiple release notes of a single major release

### DIFF
--- a/app/releases/ReleaseSection.tsx
+++ b/app/releases/ReleaseSection.tsx
@@ -1,0 +1,121 @@
+import { Accordion, AccordionDetails, AccordionSummary, Box, Typography } from "@mui/material";
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import ReleaseBody from "./ReleaseBody";
+import { GitHubReleaseData } from "@/utils/github";
+import { OrganizedReleasesType } from "@/utils/releases";
+
+interface ReleaseSectionProps {
+    mainReleaseName: string;
+    organizedReleases: OrganizedReleasesType;
+}
+
+const ReleaseSection = ({ mainReleaseName, organizedReleases }: ReleaseSectionProps) => {
+    const mainReleaseData = organizedReleases[mainReleaseName];
+
+    // Combine major and minor releases into a single array
+    const allReleases = mainReleaseData.mainRelease
+        ? [...mainReleaseData.minorReleases, mainReleaseData.mainRelease]
+        : mainReleaseData.minorReleases;
+
+    // Parse sections in reverse so that the original major version is first in the lists
+    const parsedSections = parseIntoSections(allReleases.toReversed());
+
+    const aggregatedBody = Object.entries(parsedSections).reduce(
+        (body, [sectionTitle, sectionContent]) => {
+            return (
+                body +
+                `## ${sectionTitle}\n` +
+                sectionContent.join('\n') +
+                '\n\n'
+            );
+        },
+        "",
+    );
+
+    return (
+        <Box key={mainReleaseName} pb={4}>
+            <Typography variant='h3' component='h2'>
+                {mainReleaseName[0].toUpperCase() + mainReleaseName.slice(1)}
+            </Typography>
+
+            {mainReleaseData.mainRelease &&
+                mainReleaseData.mainRelease.body !== '' ? (
+                <Box pb={4}>
+                    {/* <ReleaseBody content={mainReleaseData.mainRelease.body} /> */}
+                    <ReleaseBody content={aggregatedBody} />
+                </Box>
+            ) : null}
+
+            {allReleases.map(
+                (release: GitHubReleaseData) => (
+                    <Accordion key={release.tag_name}>
+                        <AccordionSummary
+                            expandIcon={<ArrowDropDownIcon />}
+                            aria-controls={`${release.tag_name}-content`}
+                            id={`${release.tag_name}-header`}
+                        >
+                            <Typography variant='h5' component='h2'>
+                                {release.tag_name}
+                            </Typography>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <ReleaseBody content={release.body} />
+                        </AccordionDetails>
+                    </Accordion>
+                )
+            )}
+        </Box>);
+}
+
+/**
+ * Parses the body of multiple release notes to extract sections based on the "##" headers.
+ * 
+ * @param body The body of the release notes.
+ * @returns An object where keys are section titles and values are the content of those sections.
+ */
+function parseIntoSections(releases: GitHubReleaseData[]): Record<string, string[]> {
+    const result: Record<string, string[]> = {};
+
+    for (const release of releases) {
+        const lines = release.body.split('\n');
+        let currentSection: string | null = null;
+
+        for (const line of lines) {
+            const trimmedLine = line.trim();
+
+            if (trimmedLine.startsWith('## ')) {
+                // Check if the line starts with "## " indicating a section header
+
+                currentSection = trimmedLine.slice(3).trim(); // Remove "## ", trim whitespace
+                currentSection = currentSection.replace(/:$/, ''); // Remove trailing colon if present
+                
+                if (!result[currentSection]) {
+                    result[currentSection] = []; // Initialize the section if it doesn't exist
+                }
+            } else if (currentSection && (trimmedLine.startsWith("- ") || trimmedLine.startsWith("* "))) {
+                // Check if the line is an item within a list
+
+                const placeholders = ["N/A", "None", "TBD", "...", "TODO"];
+
+                // Check if the bullet point starts with a placeholder
+                if (placeholders.some(placeholder => trimmedLine.slice(2).trim().startsWith(placeholder))) {
+                    continue;
+                } else {
+                    result[currentSection].push(trimmedLine);
+                }
+
+            }
+        }
+    }
+
+    // Remove empty sections
+    for (const section in result) {
+        if (result[section].length === 0) {
+            delete result[section];
+        }
+    }
+
+    return result;
+}
+
+export default ReleaseSection;

--- a/app/releases/ReleaseSection.tsx
+++ b/app/releases/ReleaseSection.tsx
@@ -38,12 +38,9 @@ const ReleaseSection = ({ mainReleaseName, organizedReleases }: ReleaseSectionPr
                 {mainReleaseName[0].toUpperCase() + mainReleaseName.slice(1)}
             </Typography>
 
-            {mainReleaseData.mainRelease &&
-                mainReleaseData.mainRelease.body !== '' ? (
-                <Box pb={4}>
-                    <ReleaseBody content={aggregatedBody} />
-                </Box>
-            ) : null}
+            <Box pb={4}>
+                <ReleaseBody content={aggregatedBody} />
+            </Box>
 
             {allReleases.map(
                 (release: GitHubReleaseData) => (
@@ -101,7 +98,7 @@ function parseIntoSections(releases: GitHubReleaseData[]): Record<string, string
                 if (placeholders.some(placeholder => bulletContent.startsWith(placeholder))) {
                     continue;
                 } else {
-                    // note: this pushes the bullet point itself, too
+                    // note: this pushes the bullet point itself, too (i.e. "- xyz" or "* xyz")
                     result[currentSection].push(trimmedLine);
                 }
 

--- a/app/releases/ReleaseSection.tsx
+++ b/app/releases/ReleaseSection.tsx
@@ -18,7 +18,7 @@ const ReleaseSection = ({ mainReleaseName, organizedReleases }: ReleaseSectionPr
         : mainReleaseData.minorReleases;
 
     // Parse sections in reverse so that the original major version is first in the lists
-    const parsedSections = parseIntoSections(allReleases.toReversed());
+    const parsedSections = parseIntoSections([...allReleases].reverse());
 
     const aggregatedBody = Object.entries(parsedSections).reduce(
         (body, [sectionTitle, sectionContent]) => {
@@ -41,14 +41,10 @@ const ReleaseSection = ({ mainReleaseName, organizedReleases }: ReleaseSectionPr
             {mainReleaseData.mainRelease &&
                 mainReleaseData.mainRelease.body !== '' ? (
                 <Box pb={4}>
-                    {/* <ReleaseBody content={mainReleaseData.mainRelease.body} /> */}
                     <ReleaseBody content={aggregatedBody} />
                 </Box>
             ) : null}
 
-            <Typography variant='h5' component='h3'>
-                Specific Release Notes
-            </Typography>
             {allReleases.map(
                 (release: GitHubReleaseData) => (
                     <Accordion key={release.tag_name}>

--- a/app/releases/ReleaseSection.tsx
+++ b/app/releases/ReleaseSection.tsx
@@ -46,6 +46,9 @@ const ReleaseSection = ({ mainReleaseName, organizedReleases }: ReleaseSectionPr
                 </Box>
             ) : null}
 
+            <Typography variant='h5' component='h3'>
+                Specific Release Notes
+            </Typography>
             {allReleases.map(
                 (release: GitHubReleaseData) => (
                     <Accordion key={release.tag_name}>
@@ -98,9 +101,11 @@ function parseIntoSections(releases: GitHubReleaseData[]): Record<string, string
                 const placeholders = ["N/A", "None", "TBD", "...", "TODO"];
 
                 // Check if the bullet point starts with a placeholder
-                if (placeholders.some(placeholder => trimmedLine.slice(2).trim().startsWith(placeholder))) {
+                const bulletContent = trimmedLine.slice(2).trim();
+                if (placeholders.some(placeholder => bulletContent.startsWith(placeholder))) {
                     continue;
                 } else {
+                    // note: this pushes the bullet point itself, too
                     result[currentSection].push(trimmedLine);
                 }
 

--- a/app/releases/page.tsx
+++ b/app/releases/page.tsx
@@ -12,6 +12,7 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { GitHubReleaseData } from '@/utils/github';
 import { organizeReleases } from '@/utils/releases';
 import ReleaseBody from './ReleaseBody';
+import ReleaseSection from './ReleaseSection';
 
 const Page = async () => {
   const organizedReleases = await organizeReleases();
@@ -29,43 +30,13 @@ const Page = async () => {
           }}
         />
       </Box>
-      {Object.entries(organizedReleases).map(
-        ([mainReleaseName, mainReleaseData], index) => {
-          return (
-            <Box key={index} pb={4}>
-              <Typography variant='h3' component='h2'>
-                {mainReleaseName[0].toUpperCase() + mainReleaseName.slice(1)}
-              </Typography>
-
-              {mainReleaseData.mainRelease &&
-              mainReleaseData.mainRelease.body !== '' ? (
-                <Box pb={4}>
-                  <ReleaseBody content={mainReleaseData.mainRelease.body} />
-                </Box>
-              ) : null}
-
-              {organizedReleases[mainReleaseName].minorReleases.map(
-                (release: GitHubReleaseData) => (
-                  <Accordion key={release.tag_name}>
-                    <AccordionSummary
-                      expandIcon={<ArrowDropDownIcon />}
-                      aria-controls={`${release.tag_name}-content`}
-                      id={`${release.tag_name}-header`}
-                    >
-                      <Typography variant='h5' component='h2'>
-                        {release.tag_name}
-                      </Typography>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <ReleaseBody content={release.body} />
-                    </AccordionDetails>
-                  </Accordion>
-                )
-              )}
-            </Box>
-          );
-        }
-      )}
+      {Object.keys(organizedReleases).map((mainReleaseName) => (
+        <ReleaseSection
+          key={mainReleaseName}
+          mainReleaseName={mainReleaseName}
+          organizedReleases={organizedReleases}
+        />
+      ))}
     </Container>
   );
 };


### PR DESCRIPTION
Resolves #52

Combines multiple release notes into a single preview for the `/releases` page (e.g. the release notes of v1.17.0, v1.17.1, and v1.17.2 are combined into a single big v1.17 release notes).

It does this by parsing headers starting with `## `. Then, any bullet points that follow are added to an array, which is combined between minor versions.

Note that for older versions (specifically for ~v13 or earlier) the results may be a bit jankier due to the differences in formatting. It skips over a few non-bullet-pointed items, however it's generally fine, and people can always expand the specific release notes too.